### PR TITLE
Delete '*' on line 54 in Colony.py

### DIFF
--- a/scripts/Colony.py
+++ b/scripts/Colony.py
@@ -51,7 +51,7 @@ class Colony:
             idxs_to_eat = random.choice(
                 np.argwhere(surroundings == max_surround) - 1)
 
-            resource_matrix[*(cell_coords + idxs_to_eat)] -= self.feed_rate
+            resource_matrix[(cell_coords + idxs_to_eat)] -= self.feed_rate
 
             self.feed_list[n_cell] += self.feed_rate
 


### PR DESCRIPTION
Initially when I ran the code I got a syntax error.  I just removed the '*' on line 54 and it fixed the syntax error, but maybe there was supposed to be some variable on the left-hand side of the '*' operator.  After running the code, my simulation looked reasonable.